### PR TITLE
refactor: replace @slf4j with runContext.logger()

### DIFF
--- a/src/main/java/io/kestra/plugin/hubspot/HubspotConnection.java
+++ b/src/main/java/io/kestra/plugin/hubspot/HubspotConnection.java
@@ -18,7 +18,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 import lombok.experimental.SuperBuilder;
-import lombok.extern.slf4j.Slf4j;
 import org.slf4j.Logger;
 import reactor.core.publisher.Flux;
 
@@ -30,7 +29,6 @@ import java.net.URI;
 import java.util.List;
 import java.util.Map;
 
-@Slf4j
 @SuperBuilder
 @ToString
 @EqualsAndHashCode


### PR DESCRIPTION
This PR removes unused `@Slf4j` annotations and uses execution-specific `runContext.logger()` where applicable. This aligns the plugin with project-wide logging conventions.

### What changes are being made and why?

- Removed unused `@Slf4j` annotations


Related to kestra-io/kestra#12770

***

### How the changes have been QAed?

✅ Code compiles with no errors or warnings
✅ No functional changes - refactoring only