### PR TITLE
fix: clean up HubSpot API error messages in logs

### DIFF
--- a/src/main/java/io/kestra/plugin/hubspot/HubspotConnection.java
+++ b/src/main/java/io/kestra/plugin/hubspot/HubspotConnection.java
@@ -1,10 +1,12 @@
 package io.kestra.plugin.hubspot;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.kestra.core.exceptions.IllegalVariableEvaluationException;
 import io.kestra.core.http.HttpRequest;
 import io.kestra.core.http.HttpResponse;
 import io.kestra.core.http.client.HttpClient;
+import io.kestra.core.http.client.HttpClientResponseException;
 import io.kestra.core.http.client.configurations.HttpConfiguration;
 import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.property.Property;
@@ -18,7 +20,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 import lombok.experimental.SuperBuilder;
-import org.slf4j.Logger;
 import reactor.core.publisher.Flux;
 
 import java.io.BufferedWriter;
@@ -26,6 +27,7 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.net.URI;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -37,56 +39,112 @@ import java.util.Map;
 public abstract class HubspotConnection extends Task {
 
     protected final static ObjectMapper mapper = JacksonMapper.ofJson(false);
-
     public static final String HUBSPOT_URL = "https://api.hubapi.com";
-
     public static final String JSON_CONTENT_TYPE = "application/json; charset=UTF-8";
 
-    @Schema(
-        title = "HubSpot API key"
-    )
+    @Schema(title = "HubSpot API key")
     @PluginProperty(dynamic = true)
     private Property<String> apiKey;
 
-    @Schema(
-        title = "HubSpot OAuth token"
-    )
+    @Schema(title = "HubSpot OAuth token")
     @PluginProperty(dynamic = true)
     private Property<String> oauthToken;
 
     @Schema(title = "The HTTP client configuration.")
     HttpConfiguration options;
 
-    public <T> T makeCall(RunContext runContext, HttpRequest.HttpRequestBuilder requestBuilder, Class<T> responseType) throws Exception {Logger logger = runContext.logger();
-
-        try (HttpClient client = new HttpClient(runContext,options)) {
-
+    public <T> T makeCall(RunContext runContext, HttpRequest.HttpRequestBuilder requestBuilder, Class<T> responseType) throws Exception {
+        try (HttpClient client = new HttpClient(runContext, options)) {
             HttpRequest request = requestBuilder.build();
-
             HttpResponse<T> response = client.request(request, responseType);
-
             return response.getBody();
+        } catch (HttpClientResponseException e) {
+            throw cleanHubspotException(e);
         }
+    }
+
+    /**
+     * Parses the raw HubSpot error body and returns a RuntimeException with a
+     * clean, human-readable message. The original exception is preserved as the
+     * cause so no stack trace information is lost.
+     *
+     * HubSpot error bodies look like:
+     *   [0x36]{"status":"error","message":"...","errors":[{"message":"Developer
+     *   was not one of the allowed options: [label: \"Accounting\"\nvalue:
+     *   \"accounting\"\n...]","code":"INVALID_OPTION"}]}
+     *
+     * This strips the hex-length prefix, deserialises the JSON, and collapses
+     * the YAML-style option list inside each error message down to a tidy
+     * comma-separated list of allowed values.
+     */
+    private RuntimeException cleanHubspotException(HttpClientResponseException e) {
+        String rawBody = e.getMessage();
+        if (rawBody == null) {
+            return new RuntimeException("HubSpot API error (no response body)", e);
+        }
+
+        // Strip the "[0xNN]" chunked-encoding length prefix if present
+        int jsonStart = rawBody.indexOf('{');
+        if (jsonStart < 0) {
+            return new RuntimeException("HubSpot API error: " + rawBody, e);
+        }
+        String jsonBody = rawBody.substring(jsonStart);
+
+        try {
+            HubspotErrorResponse errorResponse = mapper.readValue(jsonBody, HubspotErrorResponse.class);
+
+            List<String> cleanMessages = new ArrayList<>();
+
+            if (errorResponse.getErrors() != null) {
+                for (HubspotErrorDetail detail : errorResponse.getErrors()) {
+                    String msg = detail.getMessage();
+                    if (msg == null) {
+                        continue;
+                    }
+                    // The option list is YAML-style inside a JSON string, e.g.:
+                    //   [label: "Accounting"\nvalue: "accounting"\n..., label: ...]
+                    // Collapse each entry to just its value, producing:
+                    //   ["accounting", "administrative", ...]
+                    msg = msg.replaceAll(
+                        "label:[^,\\]]*?value:\\s*\"([^\"]+)\"[^,\\]]*?(?=[,\\]])",
+                        "\"$1\""
+                    );
+                    // Clean up any leftover escape noise
+                    msg = msg.replace("\\n", " ").replace("\\\"", "\"").trim();
+                    cleanMessages.add(msg);
+                }
+            }
+
+            if (!cleanMessages.isEmpty()) {
+                return new RuntimeException("HubSpot API error: " + String.join("; ", cleanMessages), e);
+            }
+
+            // Fallback: top-level message when the errors array is absent/empty
+            if (errorResponse.getMessage() != null) {
+                return new RuntimeException("HubSpot API error: " + errorResponse.getMessage(), e);
+            }
+
+        } catch (Exception parseException) {
+            // JSON parsing failed — return a clean message with the raw body
+            return new RuntimeException("HubSpot API error: " + jsonBody, e);
+        }
+
+        return new RuntimeException("HubSpot API error (unknown)", e);
     }
 
     public void getAuthorizedRequest(
             RunContext runContext,
             HttpRequest.HttpRequestBuilder requestBuilder) throws IllegalVariableEvaluationException {
-
         var apiKeyRendered = runContext.render(this.apiKey).as(String.class);
-
         if (apiKeyRendered.isPresent()) {
-             requestBuilder.addHeader("Authorization", "Bearer " + apiKeyRendered.get()).build();
-             return;
+            requestBuilder.addHeader("Authorization", "Bearer " + apiKeyRendered.get()).build();
+            return;
         }
-
         var authorizationTokenRendered = runContext.render(oauthToken).as(String.class);
-
         if (authorizationTokenRendered.isPresent()) {
-             requestBuilder.addHeader("Authorization", "Bearer " + authorizationTokenRendered.get()).build();
-             return;
+            requestBuilder.addHeader("Authorization", "Bearer " + authorizationTokenRendered.get()).build();
+            return;
         }
-
         throw new IllegalArgumentException("Missing required authentication fields");
     }
 
@@ -94,10 +152,8 @@ public abstract class HubspotConnection extends Task {
         return HUBSPOT_URL + getEndpoint();
     }
 
-    protected URI store(RunContext runContext, List<Map<String, Object>> results) throws IOException, IOException {
-
+    protected URI store(RunContext runContext, List<Map<String, Object>> results) throws IOException {
         File tempFile = runContext.workingDir().createTempFile(".ion").toFile();
-
         try (var output = new BufferedWriter(new FileWriter(tempFile), FileSerde.BUFFER_SIZE)) {
             Flux<Map<String, Object>> recordFlux = Flux.fromIterable(results);
             FileSerde.writeAll(output, recordFlux).block();
@@ -106,4 +162,25 @@ public abstract class HubspotConnection extends Task {
     }
 
     protected abstract String getEndpoint();
+
+    // -------------------------------------------------------------------------
+    // Error deserialization models
+    // -------------------------------------------------------------------------
+
+    @Getter
+    @NoArgsConstructor
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    protected static class HubspotErrorResponse {
+        private String status;
+        private String message;
+        private List<HubspotErrorDetail> errors;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    protected static class HubspotErrorDetail {
+        private String message;
+        private String code;
+    }
 }

--- a/src/test/java/io/kestra/plugin/hubspot/HubspotConnectionTest.java
+++ b/src/test/java/io/kestra/plugin/hubspot/HubspotConnectionTest.java
@@ -57,7 +57,6 @@ class HubspotConnectionTest {
 
     @Test
     void shouldRemoveEscapeSequencesFromErrorMessage() throws Exception {
-        // This is the exact raw JSON body from issue #35
         String rawJson = "{\"status\":\"error\","
             + "\"message\":\"Property values were not valid\","
             + "\"errors\":[{"
@@ -70,12 +69,10 @@ class HubspotConnectionTest {
 
         RuntimeException result = invokeClean(fakeException(rawJson));
 
-        // Should contain a clean, readable message
         assertThat(result.getMessage(), containsString("HubSpot API error:"));
         assertThat(result.getMessage(), containsString("accounting"));
         assertThat(result.getMessage(), containsString("administrative"));
 
-        // Should NOT contain the raw escape noise from the original error
         assertThat(result.getMessage(), not(containsString("\\n")));
         assertThat(result.getMessage(), not(containsString("\\\"Accounting\\\"")));
         assertThat(result.getMessage(), not(containsString("display_order")));
@@ -92,7 +89,6 @@ class HubspotConnectionTest {
         HttpClientResponseException original = fakeException(rawJson);
         RuntimeException result = invokeClean(original);
 
-        // Original must be preserved as cause so no stack trace is lost
         assertThat(result.getCause(), org.hamcrest.Matchers.is(original));
     }
 

--- a/src/test/java/io/kestra/plugin/hubspot/HubspotConnectionTest.java
+++ b/src/test/java/io/kestra/plugin/hubspot/HubspotConnectionTest.java
@@ -1,0 +1,129 @@
+package io.kestra.plugin.hubspot;
+
+import java.lang.reflect.Method;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+import org.junit.jupiter.api.Test;
+
+import io.kestra.core.http.HttpResponse;
+import io.kestra.core.http.client.HttpClientResponseException;
+import io.kestra.core.junit.annotations.KestraTest;
+
+@KestraTest
+class HubspotConnectionTest {
+
+    /**
+     * Builds a fake HttpClientResponseException using the same message format
+     * that FailedResponseInterceptor produces:
+     *   "Failed http request with response code '400' and body:\n<rawJson>"
+     */
+    private HttpClientResponseException fakeException(String rawJson) throws Exception {
+        String message = "Failed http request with response code '400' and body:\n" + rawJson;
+
+        // HttpClientResponseException(String message, HttpResponse<?> response)
+        // HttpResponse is a @Value Lombok class — build a minimal one via its builder
+        HttpResponse<?> fakeResponse = HttpResponse.builder()
+            .status(HttpResponse.Status.builder().code(400).reason("Bad Request").build())
+            .request(null)
+            .headers(null)
+            .body(null)
+            .endpointDetail(null)
+            .build();
+
+        return new HttpClientResponseException(message, fakeResponse);
+    }
+
+    /**
+     * Invokes the private cleanHubspotException method via reflection so we can
+     * test it without changing its visibility.
+     */
+    private RuntimeException invokeClean(HttpClientResponseException e) throws Exception {
+        // Use a concrete anonymous subclass to instantiate the abstract class
+        HubspotConnection instance = new HubspotConnection() {
+            @Override
+            protected String getEndpoint() {
+                return "/test";
+            }
+        };
+
+        Method method = HubspotConnection.class.getDeclaredMethod(
+            "cleanHubspotException", HttpClientResponseException.class
+        );
+        method.setAccessible(true);
+        return (RuntimeException) method.invoke(instance, e);
+    }
+
+    @Test
+    void shouldRemoveEscapeSequencesFromErrorMessage() throws Exception {
+        // This is the exact raw JSON body from issue #35
+        String rawJson = "{\"status\":\"error\","
+            + "\"message\":\"Property values were not valid\","
+            + "\"errors\":[{"
+            + "\"message\":\"Developer was not one of the allowed options: "
+            + "[label: \\\"Accounting\\\"\\nvalue: \\\"accounting\\\"\\n"
+            + "display_order: 0\\nhidden: false\\nread_only: false\\n, "
+            + "label: \\\"Administrative\\\"\\nvalue: \\\"administrative\\\"\\n"
+            + "display_order: 1\\nhidden: false\\nread_only: false\\n]\","
+            + "\"code\":\"INVALID_OPTION\"}]}";
+
+        RuntimeException result = invokeClean(fakeException(rawJson));
+
+        // Should contain a clean, readable message
+        assertThat(result.getMessage(), containsString("HubSpot API error:"));
+        assertThat(result.getMessage(), containsString("accounting"));
+        assertThat(result.getMessage(), containsString("administrative"));
+
+        // Should NOT contain the raw escape noise from the original error
+        assertThat(result.getMessage(), not(containsString("\\n")));
+        assertThat(result.getMessage(), not(containsString("\\\"Accounting\\\"")));
+        assertThat(result.getMessage(), not(containsString("display_order")));
+        assertThat(result.getMessage(), not(containsString("hidden: false")));
+        assertThat(result.getMessage(), not(containsString("read_only: false")));
+    }
+
+    @Test
+    void shouldPreserveOriginalExceptionAsCause() throws Exception {
+        String rawJson = "{\"status\":\"error\","
+            + "\"message\":\"Some error\","
+            + "\"errors\":[{\"message\":\"Invalid value\",\"code\":\"INVALID_OPTION\"}]}";
+
+        HttpClientResponseException original = fakeException(rawJson);
+        RuntimeException result = invokeClean(original);
+
+        // Original must be preserved as cause so no stack trace is lost
+        assertThat(result.getCause(), org.hamcrest.Matchers.is(original));
+    }
+
+    @Test
+    void shouldFallBackToTopLevelMessageWhenErrorsArrayIsEmpty() throws Exception {
+        String rawJson = "{\"status\":\"error\","
+            + "\"message\":\"Something went wrong\","
+            + "\"errors\":[]}";
+
+        RuntimeException result = invokeClean(fakeException(rawJson));
+
+        assertThat(result.getMessage(), containsString("Something went wrong"));
+    }
+
+    @Test
+    void shouldHandleNullBodyGracefully() throws Exception {
+        HttpResponse<?> fakeResponse = HttpResponse.builder()
+            .status(HttpResponse.Status.builder().code(400).reason("Bad Request").build())
+            .request(null)
+            .headers(null)
+            .body(null)
+            .endpointDetail(null)
+            .build();
+
+        // Message with no JSON body at all
+        HttpClientResponseException e = new HttpClientResponseException(
+            "Failed http request with response code '400'", fakeResponse
+        );
+
+        RuntimeException result = invokeClean(e);
+
+        assertThat(result.getMessage(), containsString("HubSpot API error"));
+    }
+}


### PR DESCRIPTION
Fixes #35

When HubSpot returns a 400 validation error, the raw HTTP body contains 
double-escaped JSON with YAML-formatted option lists, making logs very noisy.

This change catches `HttpClientResponseException` in `makeCall()`, parses the 
JSON body, strips the YAML formatting from option lists, and re-throws with a 
clean, human-readable error message.

The original exception is preserved as the cause so no stack trace is lost.

---

### Contributor Checklist ✅

- [x] I have read and followed the [plugin contribution guidelines](https://kestra.io/docs/plugin-developer-guide/contribution-guidelines)
