### PR TITLE
feat: add @PluginProperty group annotations

### DIFF
--- a/src/main/java/io/kestra/plugin/hubspot/AbstractCreateTask.java
+++ b/src/main/java/io/kestra/plugin/hubspot/AbstractCreateTask.java
@@ -8,6 +8,7 @@ import io.kestra.core.models.property.Property;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -20,6 +21,7 @@ public abstract class AbstractCreateTask extends HubspotConnection {
         title = "Additional HubSpot properties",
         description = "Optional key-value map merged into the request body. Property names must match HubSpot field keys."
     )
+    @PluginProperty(group = "advanced")
     protected Property<Map<String, Object>> additionalProperties;
 
     @Getter

--- a/src/main/java/io/kestra/plugin/hubspot/AbstractGetTask.java
+++ b/src/main/java/io/kestra/plugin/hubspot/AbstractGetTask.java
@@ -10,6 +10,7 @@ import io.kestra.core.runners.RunContext;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -22,6 +23,7 @@ public abstract class AbstractGetTask extends HubspotConnection {
         title = "Specific properties to include in the response",
         description = "Optional list of property names. Leave empty to return all properties."
     )
+    @PluginProperty(group = "advanced")
     private Property<List<String>> properties;
 
     public Output run(RunContext runContext, String recordId) throws Exception {

--- a/src/main/java/io/kestra/plugin/hubspot/AbstractSearchTask.java
+++ b/src/main/java/io/kestra/plugin/hubspot/AbstractSearchTask.java
@@ -12,6 +12,7 @@ import io.kestra.core.runners.RunContext;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -24,17 +25,20 @@ public abstract class AbstractSearchTask extends HubspotConnection {
         title = "Search default text properties",
         description = "Full-text query across default text properties for the target object. See [HubSpot search docs](https://developers.hubspot.com/docs/api/crm/search) for query semantics."
     )
+    @PluginProperty(group = "processing")
     private Property<String> query;
 
     @Schema(
         title = "Filter groups for the search query"
     )
+    @PluginProperty(group = "advanced")
     private Property<List<Map<String, Object>>> filterGroups;
 
     @Schema(
         title = "Specific properties to include in the response",
         description = "Optional list of property names. Leave empty to return all properties."
     )
+    @PluginProperty(group = "advanced")
     private Property<List<String>> properties;
 
     @Schema(
@@ -42,16 +46,19 @@ public abstract class AbstractSearchTask extends HubspotConnection {
         description = "Default is 10; maximum allowed by HubSpot is 100."
     )
     @Builder.Default
+    @PluginProperty(group = "advanced")
     private Property<Integer> limit = Property.ofValue(10);
 
     @Schema(
         title = "Pagination token for fetching the next page of results"
     )
+    @PluginProperty(group = "advanced")
     private Property<String> after;
 
     @Schema(
         title = "Sort options for the results"
     )
+    @PluginProperty(group = "advanced")
     private Property<List<Map<String, String>>> sorts;
 
     @Schema(
@@ -59,6 +66,7 @@ public abstract class AbstractSearchTask extends HubspotConnection {
         description = "If true, iterates pages until exhausted. Default is false; set to true to retrieve the full result set."
     )
     @Builder.Default
+    @PluginProperty(group = "execution")
     private Property<Boolean> fetchAllPages = Property.ofValue(false);
 
     public Output run(RunContext runContext) throws Exception {

--- a/src/main/java/io/kestra/plugin/hubspot/AbstractUpdateTask.java
+++ b/src/main/java/io/kestra/plugin/hubspot/AbstractUpdateTask.java
@@ -8,6 +8,7 @@ import io.kestra.core.models.property.Property;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -20,6 +21,7 @@ public abstract class AbstractUpdateTask extends HubspotConnection {
         title = "Additional HubSpot properties",
         description = "Optional key-value map merged into the PATCH body. Property names must match HubSpot field keys."
     )
+    @PluginProperty(group = "advanced")
     protected Property<Map<String, Object>> additionalProperties;
 
     @Getter

--- a/src/main/java/io/kestra/plugin/hubspot/HubspotConnection.java
+++ b/src/main/java/io/kestra/plugin/hubspot/HubspotConnection.java
@@ -45,11 +45,11 @@ public abstract class HubspotConnection extends Task {
     public static final String JSON_CONTENT_TYPE = "application/json; charset=UTF-8";
 
     @Schema(title = "HubSpot API key")
-    @PluginProperty(dynamic = true)
+    @PluginProperty(dynamic = true, group = "connection")
     private Property<String> apiKey;
 
     @Schema(title = "HubSpot OAuth token")
-    @PluginProperty(dynamic = true)
+    @PluginProperty(dynamic = true, group = "connection")
     private Property<String> oauthToken;
 
     @Schema(title = "The HTTP client configuration.")

--- a/src/main/java/io/kestra/plugin/hubspot/companies/Create.java
+++ b/src/main/java/io/kestra/plugin/hubspot/companies/Create.java
@@ -20,6 +20,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -63,6 +64,7 @@ public class Create extends AbstractCreateTask implements RunnableTask<AbstractC
         description = "Required company name."
     )
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> name;
 
     @Schema(
@@ -70,24 +72,28 @@ public class Create extends AbstractCreateTask implements RunnableTask<AbstractC
         description = "Required primary company domain."
     )
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> domain;
 
     @Schema(
         title = "Company description",
         description = "Optional description text."
     )
+    @PluginProperty(group = "advanced")
     private Property<String> companyDescription;
 
     @Schema(
         title = "Company industry",
         description = "HubSpot industry code (e.g., ACCOUNTING)."
     )
+    @PluginProperty(group = "advanced")
     private Property<String> industry;
 
     @Schema(
         title = "Company type",
         description = "Optional HubSpot type value such as CUSTOMER, PROSPECT, or PARTNER."
     )
+    @PluginProperty(group = "advanced")
     private Property<String> companyType;
 
     @Override

--- a/src/main/java/io/kestra/plugin/hubspot/companies/Delete.java
+++ b/src/main/java/io/kestra/plugin/hubspot/companies/Delete.java
@@ -15,6 +15,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -55,6 +56,7 @@ public class Delete extends AbstractDeleteTask implements RunnableTask<VoidOutpu
         description = "Required HubSpot company record ID."
     )
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> companyId;
 
     @Override

--- a/src/main/java/io/kestra/plugin/hubspot/companies/Get.java
+++ b/src/main/java/io/kestra/plugin/hubspot/companies/Get.java
@@ -14,6 +14,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -58,6 +59,7 @@ public class Get extends AbstractGetTask implements RunnableTask<AbstractGetTask
         description = "Required HubSpot company record ID."
     )
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> companyId;
 
     @Override

--- a/src/main/java/io/kestra/plugin/hubspot/companies/Update.java
+++ b/src/main/java/io/kestra/plugin/hubspot/companies/Update.java
@@ -22,6 +22,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -66,36 +67,42 @@ public class Update extends AbstractUpdateTask implements RunnableTask<AbstractU
         description = "Required HubSpot company record ID to update."
     )
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> companyId;
 
     @Schema(
         title = "Company name",
         description = "New company name; optional."
     )
+    @PluginProperty(group = "destination")
     private Property<String> name;
 
     @Schema(
         title = "Company domain",
         description = "Primary company domain; optional."
     )
+    @PluginProperty(group = "advanced")
     private Property<String> domain;
 
     @Schema(
         title = "Company description",
         description = "Optional description text."
     )
+    @PluginProperty(group = "advanced")
     private Property<String> companyDescription;
 
     @Schema(
         title = "Company industry",
         description = "HubSpot industry code (e.g., ACCOUNTING)."
     )
+    @PluginProperty(group = "advanced")
     private Property<String> industry;
 
     @Schema(
         title = "Company type",
         description = "Optional HubSpot type value such as CUSTOMER, PROSPECT, or PARTNER."
     )
+    @PluginProperty(group = "advanced")
     private Property<String> companyType;
 
     @Override

--- a/src/main/java/io/kestra/plugin/hubspot/contacts/Create.java
+++ b/src/main/java/io/kestra/plugin/hubspot/contacts/Create.java
@@ -22,6 +22,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -63,38 +64,45 @@ public class Create extends AbstractCreateTask implements RunnableTask<AbstractC
         description = "Required contact email address."
     )
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> email;
 
     @Schema(
         title = "First name"
     )
+    @PluginProperty(group = "advanced")
     private Property<String> firstName;
 
     @Schema(
         title = "Last name"
     )
+    @PluginProperty(group = "advanced")
     private Property<String> lastName;
 
     @Schema(
         title = "Phone number"
     )
+    @PluginProperty(group = "advanced")
     private Property<String> phone;
 
     @Schema(
         title = "Job title"
     )
+    @PluginProperty(group = "advanced")
     private Property<String> jobTitle;
 
     @Schema(
         title = "Lifecycle stage",
         description = "HubSpot lifecycle stage key such as subscriber, lead, customer, or opportunity."
     )
+    @PluginProperty(group = "advanced")
     private Property<String> lifecycleStage;
 
     @Schema(
         title = "Additional HubSpot properties",
         description = "Optional key-value map merged into the request body. Property names must match HubSpot field keys."
     )
+    @PluginProperty(group = "advanced")
     private Property<Map<String, Object>> additionalProperties;
 
     @Override

--- a/src/main/java/io/kestra/plugin/hubspot/contacts/Delete.java
+++ b/src/main/java/io/kestra/plugin/hubspot/contacts/Delete.java
@@ -15,6 +15,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -55,6 +56,7 @@ public class Delete extends AbstractDeleteTask implements RunnableTask<VoidOutpu
         description = "Required HubSpot contact record ID."
     )
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> contactId;
 
     @Override

--- a/src/main/java/io/kestra/plugin/hubspot/contacts/Get.java
+++ b/src/main/java/io/kestra/plugin/hubspot/contacts/Get.java
@@ -14,6 +14,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -56,6 +57,7 @@ public class Get extends AbstractGetTask implements RunnableTask<AbstractGetTask
         description = "Required HubSpot contact record ID."
     )
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> contactId;
 
     @Override

--- a/src/main/java/io/kestra/plugin/hubspot/contacts/Update.java
+++ b/src/main/java/io/kestra/plugin/hubspot/contacts/Update.java
@@ -22,6 +22,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -66,44 +67,52 @@ public class Update extends AbstractUpdateTask implements RunnableTask<AbstractU
         description = "Required HubSpot contact record ID to update."
     )
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> contactId;
 
     @Schema(
         title = "Contact email",
         description = "Contact email address; optional for updates."
     )
+    @PluginProperty(group = "advanced")
     private Property<String> email;
 
     @Schema(
         title = "First name"
     )
+    @PluginProperty(group = "advanced")
     private Property<String> firstName;
 
     @Schema(
         title = "Last name"
     )
+    @PluginProperty(group = "advanced")
     private Property<String> lastName;
 
     @Schema(
         title = "Phone number"
     )
+    @PluginProperty(group = "advanced")
     private Property<String> phone;
 
     @Schema(
         title = "Job title"
     )
+    @PluginProperty(group = "advanced")
     private Property<String> jobTitle;
 
     @Schema(
         title = "Lifecycle stage",
         description = "HubSpot lifecycle stage key such as subscriber, lead, customer, or opportunity."
     )
+    @PluginProperty(group = "advanced")
     private Property<String> lifecycleStage;
 
     @Schema(
         title = "Additional HubSpot properties",
         description = "Optional key-value map merged into the PATCH body. Property names must match HubSpot field keys."
     )
+    @PluginProperty(group = "advanced")
     private Property<Map<String, Object>> additionalProperties;
 
     @Override

--- a/src/main/java/io/kestra/plugin/hubspot/deals/Create.java
+++ b/src/main/java/io/kestra/plugin/hubspot/deals/Create.java
@@ -22,6 +22,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -65,6 +66,7 @@ public class Create extends AbstractCreateTask implements RunnableTask<AbstractC
         description = "Required HubSpot deal name (dealname)."
     )
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> name;
 
     @Schema(
@@ -72,6 +74,7 @@ public class Create extends AbstractCreateTask implements RunnableTask<AbstractC
         description = "Required pipeline identifier."
     )
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> pipeline;
 
     @Schema(
@@ -79,42 +82,49 @@ public class Create extends AbstractCreateTask implements RunnableTask<AbstractC
         description = "Required stage key within the selected pipeline."
     )
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> stage;
 
     @Schema(
         title = "Deal amount",
         description = "Optional amount value."
     )
+    @PluginProperty(group = "advanced")
     private Property<Double> amount;
 
     @Schema(
         title = "Close date",
         description = "Optional close date string (e.g., ISO 8601)."
     )
+    @PluginProperty(group = "advanced")
     private Property<String> closeDate;
 
     @Schema(
         title = "Deal type",
         description = "Optional HubSpot deal type (e.g., newbusiness or existingbusiness)."
     )
+    @PluginProperty(group = "advanced")
     private Property<String> dealType;
 
     @Schema(
         title = "Associated company IDs",
         description = "Optional list of HubSpot company record IDs to associate."
     )
+    @PluginProperty(group = "advanced")
     private Property<List<Long>> associatedCompanyIds;
 
     @Schema(
         title = "Associated contact IDs",
         description = "Optional list of HubSpot contact record IDs to associate."
     )
+    @PluginProperty(group = "advanced")
     private Property<List<Long>> associatedContactIds;
 
     @Schema(
         title = "Additional HubSpot properties",
         description = "Optional key-value map merged into the request body. Property names must match HubSpot field keys."
     )
+    @PluginProperty(group = "advanced")
     private Property<Map<String, Object>> additionalProperties;
 
     @Override

--- a/src/main/java/io/kestra/plugin/hubspot/deals/Delete.java
+++ b/src/main/java/io/kestra/plugin/hubspot/deals/Delete.java
@@ -15,6 +15,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -55,6 +56,7 @@ public class Delete extends AbstractDeleteTask implements RunnableTask<VoidOutpu
         description = "Required HubSpot deal record ID."
     )
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> dealId;
 
     @Override

--- a/src/main/java/io/kestra/plugin/hubspot/deals/Get.java
+++ b/src/main/java/io/kestra/plugin/hubspot/deals/Get.java
@@ -14,6 +14,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -57,6 +58,7 @@ public class Get extends AbstractGetTask implements RunnableTask<AbstractGetTask
         description = "Required HubSpot deal record ID."
     )
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> dealId;
 
     @Override

--- a/src/main/java/io/kestra/plugin/hubspot/deals/Update.java
+++ b/src/main/java/io/kestra/plugin/hubspot/deals/Update.java
@@ -22,6 +22,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -67,60 +68,70 @@ public class Update extends AbstractUpdateTask implements RunnableTask<AbstractU
         description = "Required HubSpot deal record ID to update."
     )
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> dealId;
 
     @Schema(
         title = "Deal name",
         description = "New deal name; optional."
     )
+    @PluginProperty(group = "destination")
     private Property<String> name;
 
     @Schema(
         title = "Pipeline ID",
         description = "Pipeline identifier for the deal; optional on update."
     )
+    @PluginProperty(group = "advanced")
     private Property<String> pipeline;
 
     @Schema(
         title = "Deal stage",
         description = "Stage key within the selected pipeline; optional."
     )
+    @PluginProperty(group = "advanced")
     private Property<String> stage;
 
     @Schema(
         title = "Deal amount",
         description = "Optional amount value."
     )
+    @PluginProperty(group = "advanced")
     private Property<Double> amount;
 
     @Schema(
         title = "Close date",
         description = "Optional close date string (e.g., ISO 8601)."
     )
+    @PluginProperty(group = "advanced")
     private Property<String> closeDate;
 
     @Schema(
         title = "Deal type",
         description = "Optional HubSpot deal type (e.g., newbusiness or existingbusiness)."
     )
+    @PluginProperty(group = "advanced")
     private Property<String> dealType;
 
     @Schema(
         title = "Associated company IDs",
         description = "Optional list of HubSpot company record IDs to associate."
     )
+    @PluginProperty(group = "advanced")
     private Property<List<Long>> associatedCompanyIds;
 
     @Schema(
         title = "Associated contact IDs",
         description = "Optional list of HubSpot contact record IDs to associate."
     )
+    @PluginProperty(group = "advanced")
     private Property<List<Long>> associatedContactIds;
 
     @Schema(
         title = "Additional HubSpot properties",
         description = "Optional key-value map merged into the PATCH body. Property names must match HubSpot field keys."
     )
+    @PluginProperty(group = "advanced")
     private Property<Map<String, Object>> additionalProperties;
 
     @Override

--- a/src/main/java/io/kestra/plugin/hubspot/tickets/Create.java
+++ b/src/main/java/io/kestra/plugin/hubspot/tickets/Create.java
@@ -17,6 +17,7 @@ import io.kestra.plugin.hubspot.HubspotResponse;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -90,18 +91,21 @@ public class Create extends AbstractCreateTask implements RunnableTask<AbstractC
         title = "Ticket subject",
         description = "Subject line for the ticket. HubSpot requires a subject on creation."
     )
+    @PluginProperty(group = "main")
     private Property<String> subject;
 
     @Schema(
         title = "Ticket body",
         description = "Body/description content of the ticket."
     )
+    @PluginProperty(group = "advanced")
     private Property<String> content;
 
     @Schema(
         title = "Ticket pipeline",
         description = "Optional pipeline ID. If omitted, HubSpot default pipeline applies."
     )
+    @PluginProperty(group = "advanced")
     private Property<Integer> pipeline;
 
     @Schema(
@@ -109,12 +113,14 @@ public class Create extends AbstractCreateTask implements RunnableTask<AbstractC
         description = "Stage ID within the pipeline. Defaults to 1."
     )
     @Builder.Default
+    @PluginProperty(group = "advanced")
     private Property<Integer> stage = Property.ofValue(1);
 
     @Schema(
         title = "Ticket priority",
         description = "Optional priority value: LOW, MEDIUM, or HIGH."
     )
+    @PluginProperty(group = "advanced")
     private Property<Priority> priority;
 
     @Override


### PR DESCRIPTION
## Summary

Add `@PluginProperty(group = "...")` annotations to task properties following the 9-group taxonomy (`main`, `connection`, `source`, `processing`, `execution`, `destination`, `reliability`, `advanced`, `deprecated`).

These annotations drive section grouping in the Kestra NoCode UI editor.

Groups are assigned from a curated CSV of 8,798 property assignments across 925 task types, with heuristic fallback for properties not in the CSV.

Part-of: https://github.com/kestra-io/kestra-ee/issues/6712